### PR TITLE
[github-actions] Added workflow to build u-boot and boot commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  ARCH: arm64
+  CROSS_COMPILE: aarch64-linux-gnu-
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    container: ubports/build-essential:bionic
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout repository
+      uses: actions/checkout@v1
+    
+    # This should be handled by the previous action but doesn't seem to work well
+    - name: Fetch submodules
+      run: |
+        git submodule init
+        git submodule update --init --recursive --depth 1
+
+    - name: Install required dependencies
+      run: |
+        apt update
+        apt install -y unzip flex bc bison kmod cpio libssl-dev device-tree-compiler python3 python3-dev swig u-boot-tools python3-distutils python3-setuptools
+
+    - name: Build u-boot
+      run: |
+        ./build.sh
+        
+    - name: Build boot commands
+      run: |
+        mkimage -C none -A arm -T script -d ./devkit/boot.cmd ./devkit/boot.scr
+        mkimage -C none -A arm -T script -d ./pinephone-1.0/boot.cmd ./pinephone-1.0/boot.scr
+        mkimage -C none -A arm -T script -d ./pinephone-1.1/boot.cmd ./pinephone-1.1/boot.scr
+        mkimage -C none -A arm -T script -d ./pinetab/boot.cmd ./pinetab/boot.scr
+
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        # Artifact name
+        name: u-boot-pinephone-${{ github.sha }}
+        # A file, directory or wildcard pattern that describes what to upload
+        path: |
+          ./*/*.bin
+          ./*/*.scr


### PR DESCRIPTION
This allows us to build u-boot and boot scripts without triggering a new build in sailfishos-porters-ci on GitLab.